### PR TITLE
Add Range header if provided, for happy media playback on Safari

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ module.exports = class s3proxy extends EventEmitter {
   createReadStream(req) {
     this.isInitialized();
     const r = s3proxy.parseRequest(req);
-    const params = { Bucket: this.bucket, Key: r.key };
+    let params = { Bucket: this.bucket, Key: r.key };
+    req.headers.range ? params.Range = req.headers.range : undefined;
     const s3request = this.s3.getObject(params);
     const s3stream = s3request.createReadStream();
     return { s3request, s3stream };

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = class s3proxy extends EventEmitter {
   createReadStream(req) {
     this.isInitialized();
     const r = s3proxy.parseRequest(req);
-    let params = { Bucket: this.bucket, Key: r.key };
+    const params = { Bucket: this.bucket, Key: r.key };
     if (req.headers.range) {
       params.Range = req.headers.range;
     }

--- a/index.js
+++ b/index.js
@@ -39,7 +39,9 @@ module.exports = class s3proxy extends EventEmitter {
     this.isInitialized();
     const r = s3proxy.parseRequest(req);
     let params = { Bucket: this.bucket, Key: r.key };
-    req.headers.range ? params.Range = req.headers.range : undefined;
+    if (req.headers.range) {
+      params.Range = req.headers.range;
+    }
     const s3request = this.s3.getObject(params);
     const s3stream = s3request.createReadStream();
     return { s3request, s3stream };


### PR DESCRIPTION
On Safari 14, when fetching media files (MP3s specifically) through an Express proxy, Safari would not correctly fetch the duration of the media unless S3 properly handled the "Range:" HTTP header, letting it pre-query for metadata.

This fix simply adds the Range: header provided by the client if provided, and passes it onto S3. 

Fixed the Safari issue!