### PR TITLE
chore: add lattice knowledge graph; backfill v4.0 history

### DIFF
--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -1,0 +1,128 @@
+---
+name: product-owner
+description: "Product owner sub-agent that manages strategy, backlog prioritization, and requirement quality using the lattice as persistent working memory. Invocable from Claude Code, CI pipelines, or any agent platform with shell access."
+model: sonnet
+color: green
+---
+
+You are a Product Owner agent. You manage the product strategy and backlog using a lattice knowledge graph. All your reasoning and decisions are recorded as lattice nodes and edges — never hold strategic state only in your context window.
+
+## TOOLS
+
+You interact with the lattice exclusively through CLI commands with `--format json`:
+
+```bash
+# Discovery
+lattice help --json               # Full command catalog
+lattice summary --format json     # Status overview
+lattice list requirements --format json
+lattice search --priority P0 --resolution unresolved --format json
+
+# Deep read
+lattice get REQ-XXX-001 --format json
+lattice drift --format json
+lattice lint --format json
+
+# Write
+lattice add requirement --id REQ-XXX --title "..." --body "..." --priority P1 --category XXX --format json
+lattice add thesis --id THX-XXX --title "..." --body "..." --category technical --format json
+lattice resolve REQ-XXX-001 --verified --format json
+lattice refine REQ-XXX-001 --gap-type design_decision --title "..." --description "..." --format json
+lattice verify IMP-XXX satisfies REQ-XXX --tests-pass --format json
+```
+
+## ACTIONS
+
+You support five core actions. Each must read from the lattice, reason, and write conclusions back.
+
+### 1. TRIAGE
+
+Read feedback edges, drift reports, and unresolved requirements. Output a prioritized backlog with rationale.
+
+```bash
+lattice search --resolution unresolved --format json
+lattice drift --format json
+lattice search --tag gap --format json
+```
+
+For each item, assess: urgency, dependencies, strategic alignment. Write prioritization rationale as requirement body updates or new thesis nodes.
+
+### 2. CRITIQUE
+
+Challenge existing theses against implementation evidence. If a thesis no longer holds, create a `challenges` edge.
+
+```bash
+lattice list theses --format json
+# For each thesis, check supporting evidence and implementations
+lattice search --related-to THX-XXX --format json
+```
+
+### 3. PLAN
+
+Propose the next wave of work as structured requirement nodes. Consider dependency ordering and capacity.
+
+```bash
+lattice search --priority P0 --resolution unresolved --format json
+lattice plan REQ-A REQ-B REQ-C
+```
+
+### 4. REVIEW
+
+Evaluate whether implementations satisfy linked requirements. Record `validates` or `reveals_gap_in` edges.
+
+```bash
+lattice list implementations --format json
+lattice get IMP-XXX --format json
+lattice verify IMP-XXX satisfies REQ-XXX --tests-pass --format json
+```
+
+If gaps are found:
+```bash
+lattice refine REQ-XXX --gap-type missing_requirement --title "..." --description "..." --implementation IMP-XXX --format json
+```
+
+### 5. ALIGN
+
+Check that all active requirements trace to active theses, and all theses trace to sources. Flag orphans.
+
+```bash
+lattice lint --format json
+lattice drift --check --format json
+```
+
+## WORKFLOW ENFORCEMENT
+
+For every action:
+
+1. **Read first** — Always query the lattice before making decisions
+2. **Reason explicitly** — State your reasoning before writing changes
+3. **Write back** — Every conclusion becomes a lattice node or edge
+4. **Cite evidence** — Reference specific node IDs in your reasoning
+5. **Respect proposal mode** — In interactive mode, explain changes before applying
+
+## OUTPUT FORMAT
+
+When returning results to a parent context, use this structure:
+
+```json
+{
+  "action": "triage|critique|plan|review|align",
+  "summary": "Brief description of what was done",
+  "changes": [
+    {"type": "created|updated|flagged", "id": "NODE-ID", "description": "what changed"}
+  ],
+  "recommendations": [
+    {"priority": "P0|P1|P2", "description": "what should happen next", "related_nodes": ["REQ-XXX"]}
+  ]
+}
+```
+
+## PRINCIPLES
+
+- **Lattice is source of truth** — If it's not in the lattice, it didn't happen
+- **Prose is primary** — Write clear, human-readable rationale in node bodies
+- **Decisions are durable** — Every strategic choice is a node, not a chat message
+- **Git provides audit trail** — Your changes are committed and traceable
+- **Humans can override** — Any YAML file can be edited directly
+
+Begin by running `lattice summary --format json` to understand the current state.

--- a/.claude/skills/lattice/SKILL.md
+++ b/.claude/skills/lattice/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: lattice
+description: "Lattice knowledge graph integration. Use when working in a project with a .lattice/ directory — for requirements, theses, sources, implementations, drift detection, or lattice CLI commands."
+allowed-tools: Bash(lattice *), Bash(./target/release/lattice *), Bash(./target/debug/lattice *), Bash(gh issue *), Read, Grep, Glob
+---
+
+# Lattice Skill
+
+You have access to a **Lattice** knowledge graph in this project. The `.lattice/` directory contains the structured knowledge graph (YAML files). Use the `lattice` CLI to query and modify it.
+
+The key words MUST, MUST NOT, SHOULD, SHOULD NOT, and MAY in this document are to be interpreted as described in RFC 2119.
+
+## Quick Reference
+
+```bash
+lattice summary                  # Status overview (counts, drift, health)
+lattice list requirements        # All requirements
+lattice list requirements -s active --format json  # Filtered, JSON output
+lattice get REQ-XXX-001          # Full node details with edges
+lattice plan REQ-A REQ-B         # Implementation order for requirements
+lattice drift                    # Check for stale edge bindings
+lattice lint                     # Structural issues
+lattice search -q "keyword"      # Text search (defaults to requirements)
+lattice edit REQ-XXX --title "..." # Edit node fields (auto-bumps version)
+lattice add edge --from IMP-XXX --type satisfies --to REQ-XXX  # Wire edges
+lattice remove edge --from IMP-XXX --type satisfies --to REQ-XXX  # Remove edges
+lattice replace edge --from IMP-XXX --type satisfies --old-to REQ-OLD --new-to REQ-NEW  # Retarget edges
+lattice update                   # Self-update to latest version
+lattice update --check           # Check for updates without installing
+```
+
+## Editing Rules
+
+Agents MUST use the `lattice` CLI for all supported operations.
+The CLI handles timestamps, version bumps, edge wiring, and ID validation.
+
+If the CLI does not support a required operation, agents MAY edit `.lattice/` YAML files directly, but MUST run `lattice lint` immediately after to verify correctness.
+
+If a CLI gap is found, agents SHOULD file an issue on `forkzero/lattice` describing the missing capability:
+```bash
+gh issue create --repo forkzero/lattice \
+  --title "CLI gap: <what's missing>" \
+  --body "Encountered while working on <context>. Had to edit YAML directly because <reason>." \
+  --label "cli-gap"
+```
+
+## Workflow
+
+### Before Starting Work
+1. Run `lattice summary` to understand the current state
+2. Run `lattice plan` or `lattice search --priority P0 --resolution unresolved` to find what to work on
+3. Run `lattice get REQ-XXX` to read full requirement details before implementing
+
+### While Working
+- Reference requirement IDs in commits: `Implements REQ-XXX-001`
+- Use `lattice get <ID> --format json` for structured data when you need to parse output
+
+### After Completing Work
+- `lattice resolve REQ-XXX --verified` to mark requirements as done
+- `lattice verify IMP-XXX satisfies REQ-XXX --tests-pass` to record satisfaction evidence
+- If you implemented a new feature, add matching requirement(s) and resolve them as verified
+- `lattice edit IMP-XXX --body "updated description" --files "src/new.rs,src/lib.rs" --test-command "cargo test"` to update implementation nodes
+- `lattice add edge --from IMP-XXX --type satisfies --to REQ-XXX` to wire new edges
+- Run `lattice drift` to confirm no unresolved drift
+
+### If Gaps Are Found
+- `lattice refine REQ-XXX --gap-type missing_requirement --title "..." --description "..."` to create sub-requirements
+- `lattice add edge --from IMP-XXX --type reveals_gap_in --to REQ-XXX --rationale "..."` to record feedback
+
+## Node Types
+
+| Type | ID Pattern | Purpose |
+|------|-----------|---------|
+| Source | `SRC-XXX` | Research, papers, references |
+| Thesis | `THX-XXX` | Strategic claims backed by sources |
+| Requirement | `REQ-XXX-NNN` | Testable specifications derived from theses |
+| Implementation | `IMP-XXX-NNN` | Code that satisfies requirements |
+
+## Edge Types
+
+| Edge | Direction | Meaning |
+|------|----------|---------|
+| `supports` | Source → Thesis | Evidence backing a claim |
+| `derives` | Thesis → Requirement | Specification from strategy |
+| `satisfies` | Implementation → Requirement | Code fulfills spec |
+| `depends_on` | Requirement → Requirement | Dependency ordering |
+| `reveals_gap_in` | Implementation → Requirement/Thesis | Discovered underspecification |
+| `challenges` | Any → Thesis | Contradictory evidence |
+| `validates` | Implementation → Thesis | Confirming evidence |
+
+## Resolution States
+
+- `verified` — Implemented and tested
+- `blocked` — Waiting on external dependency (with reason)
+- `deferred` — Postponed to later milestone (with reason)
+- `wontfix` — Rejected or out of scope (with reason)
+
+## Adding Nodes
+
+```bash
+lattice add requirement \
+  --id REQ-FEAT-001 --title "Short description" \
+  --body "Detailed specification" --priority P1 \
+  --category FEAT --derives-from THX-XXX --created-by "agent:claude"
+
+lattice add thesis \
+  --id THX-NEW --title "Claim" --body "Reasoning" \
+  --category technical --supported-by SRC-XXX --created-by "agent:claude"
+
+lattice add source \
+  --id SRC-NEW --title "Reference" --body "Summary" \
+  --url "https://..." --created-by "agent:claude"
+
+lattice add implementation \
+  --id IMP-FEAT-001 --title "Feature implementation" \
+  --body "Description of what was implemented" \
+  --language rust --files "src/main.rs,src/lib.rs" \
+  --test-command "cargo test" --satisfies REQ-FEAT-001 \
+  --created-by "agent:claude"
+
+lattice add edge \
+  --from IMP-XXX --type validates --to THX-XXX \
+  --rationale "Implementation confirms thesis"
+```
+
+## Managing Edges
+
+```bash
+# Remove an edge
+lattice remove edge --from IMP-XXX --type satisfies --to REQ-XXX
+
+# Replace an edge target (retarget to a different node)
+lattice replace edge --from IMP-XXX --type satisfies \
+  --old-to REQ-OLD --new-to REQ-NEW --rationale "Requirement was split"
+```
+
+## Editing Nodes
+
+```bash
+lattice edit REQ-XXX --title "New title" --body "New body"
+lattice edit REQ-XXX --priority P0 --tags "core,storage"
+lattice edit IMP-XXX --files "src/new.rs,src/lib.rs" --test-command "cargo test"
+lattice edit IMP-XXX --body "Updated description" --status active
+```
+
+Agents MUST use `lattice edit` to modify existing nodes. The `edit` command auto-bumps the patch version and preserves all other fields. Type-specific flags: `--priority` (requirements only), `--files` and `--test-command` (implementations only).
+
+## JSON Output
+
+All read and write commands accept `--format json` for structured output. Use this when you need to parse results programmatically.
+
+## Drift Detection
+
+Edges are version-bound. When a node is updated, edges referencing the old version become stale. Run `lattice drift` to detect these. Use `lattice drift --check` in CI (exits non-zero on drift).
+
+## Product Owner Agent
+
+For backlog triage, strategic critique, and planning work, use the **product-owner** agent (`/product-owner`). It manages the lattice as persistent working memory for product strategy.

--- a/.gitignore
+++ b/.gitignore
@@ -84,5 +84,10 @@ typings/
 
 /coverage
 
-# Claude Code per-user tooling/prompts
-.claude/
+# Claude Code per-user tooling/prompts.
+# Ignore .claude/ contents by default, then re-include project-scoped
+# skills and agents — those teach any agent how to work with this repo
+# (e.g. lattice integration) and should be committed.
+.claude/*
+!.claude/skills/
+!.claude/agents/

--- a/.lattice/config.yaml
+++ b/.lattice/config.yaml
@@ -1,0 +1,4 @@
+# Lattice configuration
+version: "1.0"
+project: "s3proxy"
+description: "Front AWS S3 with a web server that you control"

--- a/.lattice/implementations/build-001.yaml
+++ b/.lattice/implementations/build-001.yaml
@@ -1,0 +1,25 @@
+id: IMP-BUILD-001
+type: implementation
+title: Share base tsconfig + vitest config; replace shell version-gen
+body: 'Commit 9d9b0a8 (PR #103). Created tsconfig.base.json that both tsconfig.json (build) and tsconfig.examples.json (type-check) extend. Created vitest.shared.ts with shared globals/environment/timeouts. Replaced echo > src/version.ts shell hack with createRequire(import.meta.url)(''s3proxy/package.json'') — self-reference works via the existing ./package.json exports entry, so it resolves in dev (vitest/tsx) and in the published package without copying or restructuring dist.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:57:01.028666+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  language: typescript
+  files:
+  - path: tsconfig.base.json
+  - path: tsconfig.json
+  - path: tsconfig.examples.json
+  - path: vitest.shared.ts
+  - path: vitest.config.ts
+  - path: vitest.integration.config.ts
+  - path: src/version.ts
+  - path: package.json
+  test_command: npm run build && npm test
+edges:
+  satisfies:
+  - target: REQ-BUILD-001
+    version: 1.0.0

--- a/.lattice/implementations/core-001.yaml
+++ b/.lattice/implementations/core-001.yaml
@@ -1,0 +1,20 @@
+id: IMP-CORE-001
+type: implementation
+title: Replace AWS SDK middleware-stack hack with public API
+body: 'Commit e24b4b6 (PR #103). Removed the (command as any).middlewareStack mutation, three any casts, two biome-ignore directives, and the Not sure why comment. Status now comes from output.$metadata.httpStatusCode; headers reconstructed from typed output fields via a src->dst table (OUTPUT_HEADER_MAP). Added test/streaming-memory.test.ts asserting peak RSS delta < 80MB on a 50MB synthetic stream (later tightened to <50MB on 100MB in B6).'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:57:00.991022+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  language: typescript
+  files:
+  - path: src/index.ts
+  - path: test/streaming-memory.test.ts
+  - path: vitest.config.ts
+  test_command: npm test
+edges:
+  satisfies:
+  - target: REQ-CORE-001
+    version: 1.0.0

--- a/.lattice/implementations/core-002.yaml
+++ b/.lattice/implementations/core-002.yaml
@@ -1,0 +1,22 @@
+id: IMP-CORE-002
+type: implementation
+title: Typed errors; remove silent empty-stream substitution
+body: 'Commit 5ae51a5 (PR #103). Created src/errors.ts with S3ProxyError base and S3NotFound (404) / S3Forbidden (403) / S3InvalidRange (416) / InvalidRequest (400, reserved for B3b''s parser). Replaced handleNonFatal with mapError that throws typed errors; original SDK error attached as cause. Removed S3Proxy.isNonFatalError. test/s3proxy.test.ts rewritten to drive public proxy.get + assert typed rejects. test/helpers/http-mocks.ts factored makeReq/makeRes/readAll/catchError helpers.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:57:12.101544+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  language: typescript
+  files:
+  - path: src/errors.ts
+  - path: src/index.ts
+  - path: test/s3proxy.test.ts
+  - path: test/helpers/http-mocks.ts
+  - path: scripts/smoke-examples.sh
+  test_command: npm test
+edges:
+  satisfies:
+  - target: REQ-CORE-002
+    version: 1.0.0

--- a/.lattice/implementations/core-003.yaml
+++ b/.lattice/implementations/core-003.yaml
@@ -1,0 +1,21 @@
+id: IMP-CORE-003
+type: implementation
+title: verifyOnInit option; unified init/healthCheck probe
+body: 'Commit 59aa209 (PR #103). Added verifyOnInit?: boolean to S3ProxyConfig (default true). When true, init() routes through healthCheck() — single source of truth for the probe. When false, init() resolves without S3 traffic. Three behavioral tests cover the cases. README documents the option and recommends pairing verifyOnInit:false with proxy.healthCheck() in a readiness handler.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:57:12.130405+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  language: typescript
+  files:
+  - path: src/index.ts
+  - path: src/types.ts
+  - path: test/s3proxy.test.ts
+  - path: README.md
+  test_command: npm test
+edges:
+  satisfies:
+  - target: REQ-CORE-003
+    version: 1.0.0

--- a/.lattice/implementations/core-004.yaml
+++ b/.lattice/implementations/core-004.yaml
@@ -1,0 +1,28 @@
+id: IMP-CORE-004
+type: implementation
+title: proxy.fetch(); decompose into parser + gateway; retire wrappers
+body: 'Commits 50eb260 + d3f7bc2 + 6ccbff1 (PR #103). B3a: Added public proxy.fetch(req) returning {stream, status, headers}; reimplemented get/head as thin wrappers. B3b: Extracted src/request-parser.ts (parseRequest, mapHeaderToParam, stripLeadingSlash) and src/s3-gateway.ts (S3Client lifecycle + send). Added InvalidRequest handling for malformed percent-encoding (/foo%ZZ) and null-byte keys. B3c: Deleted proxy.get(req,res), proxy.head(req,res), proxy.healthCheckStream(res). All four examples (express-basic, fastify-basic, fastify-docker, http) migrated to proxy.fetch + manual writeHead + pipe. HttpRequest loosened to structural type; HttpResponse no longer in public surface.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:57:28.964517+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  language: typescript
+  files:
+  - path: src/index.ts
+  - path: src/request-parser.ts
+  - path: src/s3-gateway.ts
+  - path: src/types.ts
+  - path: examples/express-basic.ts
+  - path: examples/fastify-basic.ts
+  - path: examples/fastify-docker.ts
+  - path: examples/http.ts
+  - path: test/fetch.test.ts
+  - path: test/parse-request.test.ts
+  - path: test/s3proxy.test.ts
+  test_command: npm test && npm run type-check && bash scripts/smoke-examples.sh
+edges:
+  satisfies:
+  - target: REQ-CORE-004
+    version: 1.0.0

--- a/.lattice/implementations/docs-001.yaml
+++ b/.lattice/implementations/docs-001.yaml
@@ -1,0 +1,19 @@
+id: IMP-DOCS-001
+type: implementation
+title: Prune root markdown bloat; revise credentials guidance
+body: 'Commit df07312 (PR #103). Removed 7 stale root markdown files (MIGRATION_SUMMARY, RELEASE*.md, TODO, AI_ASSISTED_DEVELOPMENT_RULES, S3PROXY_DOCKER_ADAPTATION_GUIDE). Moved MAINTENANCE.md to docs/maintenance.md and PERFORMANCE.md to docs/performance.md. README''s Docker section now points to ~/.s3proxy/credentials.json with a bind-mount, keeping STS tokens out of the working copy. credentials.json itself remains gitignored as intentional dev tooling.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:57:01.055994+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  language: markdown
+  files:
+  - path: README.md
+  - path: docs/maintenance.md
+  - path: docs/performance.md
+edges:
+  satisfies:
+  - target: REQ-DOCS-001
+    version: 1.0.0

--- a/.lattice/implementations/example-001.yaml
+++ b/.lattice/implementations/example-001.yaml
@@ -1,0 +1,21 @@
+id: IMP-EXAMPLE-001
+type: implementation
+title: Hono example for Web Standards runtimes
+body: 'PR #106 (commits 981fa74 + 274a722 + 6b01de4). examples/hono-basic.ts uses proxy.fetch() with Object.fromEntries(c.req.raw.headers) to bridge Web Headers to HttpRequest''s Record (path-A from #104), and Readable.toWeb(stream) to bridge Node Readable to Web ReadableStream for the Response body. app.on([''GET'',''HEAD''],''/*'',...) shares one handler. Smoke gate extended with per-example latency baseline (10 sequential GETs, mean/max/p95). README documents the perf tradeoff. Local smoke: mean=55-58ms across express/fastify/hono — network-bound parity.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:57:29.055437+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  language: typescript
+  files:
+  - path: examples/hono-basic.ts
+  - path: scripts/smoke-examples.sh
+  - path: README.md
+  - path: package.json
+  test_command: bash scripts/smoke-examples.sh
+edges:
+  satisfies:
+  - target: REQ-EXAMPLE-001
+    version: 1.0.0

--- a/.lattice/implementations/test-001.yaml
+++ b/.lattice/implementations/test-001.yaml
@@ -1,0 +1,24 @@
+id: IMP-TEST-001
+type: implementation
+title: Behavioral coverage; remove implementation tests; smoke gate
+body: 'Commits 301a98a + e2c9b9b (PR #103). Phase 0 added scripts/smoke-examples.sh that boots each example on a free port and asserts /health=200, /index.html=200, and a missing key returns 404 (the v3->v4 empty-200->404 transition). B6 final sweep: zero ''as any'' in test/, zero ''(proxy as any)'' in test/, biome check 0/0. Removed test/types.test.ts (tests TS not behavior), test/integration-tests.js (mocha legacy), test/mocha.opts. Added test/concurrent.test.ts (10 parallel fetch calls, distinct streams/bytes), tightened test/streaming-memory.test.ts to 100MB body / <50MB peak RSS delta.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:57:29.011183+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  language: typescript
+  files:
+  - path: test/s3proxy.test.ts
+  - path: test/fetch.test.ts
+  - path: test/concurrent.test.ts
+  - path: test/streaming-memory.test.ts
+  - path: test/helpers/http-mocks.ts
+  - path: test/helpers/aws-mock.ts
+  - path: scripts/smoke-examples.sh
+  test_command: npm test && bash scripts/smoke-examples.sh
+edges:
+  satisfies:
+  - target: REQ-TEST-001
+    version: 1.0.0

--- a/.lattice/requirements/build/001-share-base-tsconfig---vitest-config--rep.yaml
+++ b/.lattice/requirements/build/001-share-base-tsconfig---vitest-config--rep.yaml
@@ -1,0 +1,22 @@
+id: REQ-BUILD-001
+type: requirement
+title: Share base tsconfig + vitest config; replace shell version-gen
+body: 'GH issue #96. Extract tsconfig.base.json that both tsconfig.json and tsconfig.examples.json extend. Extract vitest.shared.ts so unit and integration configs don''t duplicate globals/environment/timeouts. Replace npm pkg get | sed | echo > version.ts shell hack with createRequire-based JSON import. Delete the now-redundant version.ts generation.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:56:11.690440+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+priority: P1
+category: BUILD
+tags:
+- tooling
+- build
+resolution:
+  status: verified
+  resolved_at: 2026-05-11T22:59:43.631323+00:00
+  resolved_by: agent:claude-2026-05-11
+edges:
+  derives_from:
+  - target: THX-DECOMPOSE
+    version: 1.0.0

--- a/.lattice/requirements/core/001-replace-aws-sdk-middleware-stack-hack-wi.yaml
+++ b/.lattice/requirements/core/001-replace-aws-sdk-middleware-stack-hack-wi.yaml
@@ -1,0 +1,22 @@
+id: REQ-CORE-001
+type: requirement
+title: Replace AWS SDK middleware-stack hack with public API
+body: 'GH issue #95. src/index.ts lines 173-188 in v3 used (command as any).middlewareStack with three any casts to capture response metadata. Replace with output.$metadata.httpStatusCode for status and reconstruct headers from typed AWS SDK output fields. Zero any, zero biome-ignore, zero ''Not sure why'' comment. Add a streaming-memory test asserting peak RSS delta on a synthetic 50MB body.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:56:11.659059+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+priority: P0
+category: CORE
+tags:
+- aws-sdk
+- refactor
+resolution:
+  status: verified
+  resolved_at: 2026-05-11T22:59:43.595776+00:00
+  resolved_by: agent:claude-2026-05-11
+edges:
+  derives_from:
+  - target: THX-SDK-PUBLIC-API
+    version: 1.0.0

--- a/.lattice/requirements/core/002-throw-typed-errors-instead-of-silent-emp.yaml
+++ b/.lattice/requirements/core/002-throw-typed-errors-instead-of-silent-emp.yaml
@@ -1,0 +1,22 @@
+id: REQ-CORE-002
+type: requirement
+title: Throw typed errors instead of silent empty-stream substitution
+body: 'GH issue #98. Create src/errors.ts with S3ProxyError base + S3NotFound (404), S3Forbidden (403), S3InvalidRange (416), InvalidRequest (400 for parser). Map AWS SDK errors via mapError(). Remove S3Proxy.isNonFatalError (vestigial). Original SDK error attached as cause. BREAKING: v3 returned an empty 200 stream for these cases.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:56:25.252014+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+priority: P0
+category: CORE
+tags:
+- errors
+- breaking
+resolution:
+  status: verified
+  resolved_at: 2026-05-11T22:59:43.605852+00:00
+  resolved_by: agent:claude-2026-05-11
+edges:
+  derives_from:
+  - target: THX-TYPED-ERRORS
+    version: 1.0.0

--- a/.lattice/requirements/core/003-add-verifyoninit-option--default-true--f.yaml
+++ b/.lattice/requirements/core/003-add-verifyoninit-option--default-true--f.yaml
@@ -1,0 +1,22 @@
+id: REQ-CORE-003
+type: requirement
+title: Add verifyOnInit option (default true) for orchestrator deployments
+body: 'GH issue #99. Add verifyOnInit?: boolean to S3ProxyConfig (default true). When true, init() calls healthCheck() (existing fail-fast behavior). When false, init() resolves without S3 traffic, leaving health to proxy.healthCheck() called from a readiness handler. README documents the orchestrator use case.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:56:25.289337+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+priority: P1
+category: CORE
+tags:
+- config
+- k8s
+resolution:
+  status: verified
+  resolved_at: 2026-05-11T22:59:43.614259+00:00
+  resolved_by: agent:claude-2026-05-11
+edges:
+  derives_from:
+  - target: THX-FAIL-FAST-OPT-OUT
+    version: 1.0.0

--- a/.lattice/requirements/core/004-introduce-proxy-fetch----decompose-into-.yaml
+++ b/.lattice/requirements/core/004-introduce-proxy-fetch----decompose-into-.yaml
@@ -1,0 +1,25 @@
+id: REQ-CORE-004
+type: requirement
+title: Introduce proxy.fetch(); decompose into parser + gateway; retire wrappers
+body: 'GH issue #100. Three sub-steps: (B3a) Add public proxy.fetch(req) returning {stream, status, headers}, reimplement get/head as wrappers. (B3b) Extract src/request-parser.ts (parseRequest, mapHeaderToParam, stripLeadingSlash) and src/s3-gateway.ts (S3Client lifecycle, send). Add InvalidRequest for malformed percent-encoding and null-byte keys. (B3c) Delete proxy.get/head/healthCheckStream entirely; examples migrate to fetch + manual writeHead + pipe. BREAKING.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:56:25.315978+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+priority: P0
+category: CORE
+tags:
+- api
+- breaking
+- refactor
+resolution:
+  status: verified
+  resolved_at: 2026-05-11T22:59:43.622632+00:00
+  resolved_by: agent:claude-2026-05-11
+edges:
+  derives_from:
+  - target: THX-PURE-FETCH
+    version: 1.0.0
+  - target: THX-DECOMPOSE
+    version: 1.0.0

--- a/.lattice/requirements/docs/001-prune-root-markdown-bloat--revise-creden.yaml
+++ b/.lattice/requirements/docs/001-prune-root-markdown-bloat--revise-creden.yaml
@@ -1,0 +1,22 @@
+id: REQ-DOCS-001
+type: requirement
+title: Prune root markdown bloat; revise credentials guidance
+body: 'GH issue #97. Delete seven stale root markdown files (MIGRATION_SUMMARY, RELEASE*.md, TODO, AI_ASSISTED, S3PROXY_DOCKER_ADAPTATION). Move MAINTENANCE.md and PERFORMANCE.md to docs/. Update README''s credentials section: place credentials.json at ~/.s3proxy/ and bind-mount from there (not the repo root). credentials.json remains intentional dev tooling.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:56:11.717816+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+priority: P2
+category: DOCS
+tags:
+- hygiene
+- docs
+resolution:
+  status: verified
+  resolved_at: 2026-05-11T22:59:43.638859+00:00
+  resolved_by: agent:claude-2026-05-11
+edges:
+  derives_from:
+  - target: THX-DECOMPOSE
+    version: 1.0.0

--- a/.lattice/requirements/example/001-hono-example-for-web-standards-runtimes.yaml
+++ b/.lattice/requirements/example/001-hono-example-for-web-standards-runtimes.yaml
@@ -1,0 +1,25 @@
+id: REQ-EXAMPLE-001
+type: requirement
+title: Hono example for Web Standards runtimes
+body: 'GH issue #104. Add examples/hono-basic.ts demonstrating proxy.fetch() integration with Hono on Node (via @hono/node-server) and by extension Bun/Workers/Deno. Use Object.fromEntries(c.req.raw.headers) to adapt Web Headers to HttpRequest''s Record. Use Readable.toWeb(stream) for the Web Response body. Wire into smoke gate. README documents the perf tradeoff (two extra conversion layers on Node, unmeasurable for network-bound streaming).'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:56:42.949340+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+priority: P2
+category: EXAMPLE
+tags:
+- hono
+- web-standards
+- examples
+resolution:
+  status: verified
+  resolved_at: 2026-05-11T22:59:43.652216+00:00
+  resolved_by: agent:claude-2026-05-11
+edges:
+  derives_from:
+  - target: THX-PURE-FETCH
+    version: 1.0.0
+  - target: THX-WEB-STANDARDS
+    version: 1.0.0

--- a/.lattice/requirements/test/001-behavioral-coverage--zero--proxy-as-any-.yaml
+++ b/.lattice/requirements/test/001-behavioral-coverage--zero--proxy-as-any-.yaml
@@ -1,0 +1,25 @@
+id: REQ-TEST-001
+type: requirement
+title: Behavioral coverage; zero (proxy as any); examples smoke gate
+body: 'GH issue #101. Final test sweep: grep -rn ''as any'' test/ returns zero. Delete test/types.test.ts (tests TypeScript, not behavior). Rewrite test/s3proxy.test.ts to drive public proxy.fetch() not private getObject. Add behavioral coverage for S3NotFound, S3Forbidden (with cause), S3InvalidRange, concurrent fetch (10 parallel, distinct streams), streaming-memory (100MB body, peak RSS delta < 50MB). Create scripts/smoke-examples.sh that boots each example, asserts /health=200, /index.html=200, and a missing key returns 404.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:56:42.912850+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+priority: P1
+category: TEST
+tags:
+- tests
+- smoke
+- discipline
+resolution:
+  status: verified
+  resolved_at: 2026-05-11T22:59:43.645698+00:00
+  resolved_by: agent:claude-2026-05-11
+edges:
+  derives_from:
+  - target: THX-TYPED-ERRORS
+    version: 1.0.0
+  - target: THX-PURE-FETCH
+    version: 1.0.0

--- a/.lattice/sources/aws-sdk-mw.yaml
+++ b/.lattice/sources/aws-sdk-mw.yaml
@@ -1,0 +1,13 @@
+id: SRC-AWS-SDK-MW
+type: source
+title: AWS SDK v3 middleware stack blog post
+body: Original AWS blog explaining the modular middleware stack in AWS SDK v3. v3 of s3proxy reached into command.middlewareStack with three any casts and a Not sure why comment about priority:low — this source is the authoritative reference for that approach. v4 abandoned the middleware approach in favor of typed $metadata.httpStatusCode and reconstructed headers from typed output.
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:55:33.945024+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  url: https://aws.amazon.com/blogs/developer/middleware-stack-modular-aws-sdk-js/
+  reliability: industry
+  retrieved_at: 2026-05-11

--- a/.lattice/sources/hono-pr.yaml
+++ b/.lattice/sources/hono-pr.yaml
@@ -1,0 +1,13 @@
+id: SRC-HONO-PR
+type: source
+title: 'Hono example PR #106'
+body: 'PR #106 added examples/hono-basic.ts demonstrating proxy.fetch() integration with a Web-Standards framework. Captures the path-A decision from #104 (adapt Web Headers to Record at the example boundary rather than widening HttpRequest). Includes per-example latency baseline (mean=55-58ms across express/fastify/hono on /index.html) confirming network-bound parity.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:55:36.444878+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  url: https://github.com/gmoon/s3proxy/pull/106
+  reliability: industry
+  retrieved_at: 2026-05-11

--- a/.lattice/sources/v4-migration.yaml
+++ b/.lattice/sources/v4-migration.yaml
@@ -1,0 +1,13 @@
+id: SRC-V4-MIGRATION
+type: source
+title: MIGRATION.md v4.0
+body: 'User-facing migration document shipped in PR #103. Documents the v3 to v4 breaking changes (typed errors, removal of proxy.get/head/healthCheckStream, free-function exports of parseRequest et al., structural HttpRequest), the new verifyOnInit option, and where errors fire (throw from fetch() vs v3''s silent empty-stream).'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:55:30.846812+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  url: https://github.com/gmoon/s3proxy/blob/master/MIGRATION.md
+  reliability: industry
+  retrieved_at: 2026-05-11

--- a/.lattice/sources/v4-prompt.yaml
+++ b/.lattice/sources/v4-prompt.yaml
@@ -1,0 +1,12 @@
+id: SRC-V4-PROMPT
+type: source
+title: v4.0 refactor prompt
+body: The original brief that drove the v4.0 work. Specified the seven sub-issues (#95-#101), the additive-then-subtractive migration pattern, the non-negotiable gate discipline (every commit leaves all gates passing), and the simplify-per-issue requirement. Lives at .claude/prompts/v4-refactor.md in the worktree at start of work; intentionally not committed to master.
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:55:28.330328+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  reliability: industry
+  retrieved_at: 2026-05-11

--- a/.lattice/theses/decompose.yaml
+++ b/.lattice/theses/decompose.yaml
@@ -1,0 +1,16 @@
+id: THX-DECOMPOSE
+type: thesis
+title: The 288-line S3Proxy god class needs parser + gateway + orchestrator split
+body: v3's src/index.ts mixed HTTP request parsing, AWS SDK lifecycle, response shaping, error classification, and framework-facing API in one class. Decomposing into src/request-parser.ts (pure functions), src/s3-gateway.ts (SDK boundary), and a slimmed src/index.ts (orchestrator) makes each piece individually testable, unblocks framework adapters (Hono via Web Standards), and reduces blast radius of any future SDK change.
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:55:48.056504+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  category: technical
+  confidence: 0.9
+edges:
+  supported_by:
+  - target: SRC-V4-PROMPT
+    version: 1.0.0

--- a/.lattice/theses/fail-fast-opt-out.yaml
+++ b/.lattice/theses/fail-fast-opt-out.yaml
@@ -1,0 +1,16 @@
+id: THX-FAIL-FAST-OPT-OUT
+type: thesis
+title: Default fail-fast on init; opt-out for orchestrators (verifyOnInit)
+body: 'v3 always probed the bucket on init(). For most apps fail-fast is right — a misconfigured bucket should crash at startup, not on first request. But in orchestrator deployments (Kubernetes, ECS) a transient S3 hiccup would crashloop the pod before logs/dashboards were wired up. Solution: verifyOnInit default true preserves existing behavior; setting false defers the probe so the platform''s readiness probe drives health.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:55:53.818979+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  category: technical
+  confidence: 0.85
+edges:
+  supported_by:
+  - target: SRC-V4-PROMPT
+    version: 1.0.0

--- a/.lattice/theses/pure-fetch.yaml
+++ b/.lattice/theses/pure-fetch.yaml
@@ -1,0 +1,20 @@
+id: THX-PURE-FETCH
+type: thesis
+title: proxy.fetch(req) returning {stream, status, headers} enables any framework
+body: 'v3''s proxy.get(req, res) mutated the response — coupling the library to Node''s ServerResponse. A pure proxy.fetch() that returns a structured triple works for Express, Fastify, Hono, raw http, Web Response, and any future runtime. Validated by the Hono example (PR #106) which uses the same proxy.fetch() that Express and Fastify use, with no library changes.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:55:50.706349+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  category: value_prop
+  confidence: 0.95
+edges:
+  supported_by:
+  - target: SRC-V4-PROMPT
+    version: 1.0.0
+  - target: SRC-V4-MIGRATION
+    version: 1.0.0
+  - target: SRC-HONO-PR
+    version: 1.0.0

--- a/.lattice/theses/sdk-public-api.yaml
+++ b/.lattice/theses/sdk-public-api.yaml
@@ -1,0 +1,18 @@
+id: THX-SDK-PUBLIC-API
+type: thesis
+title: Reaching into AWS SDK internals is a maintenance hazard
+body: v3 mutated command.middlewareStack on every request with three any casts and a Not sure why comment about priority:low. The middleware approach broke on any SDK refactor. v4 uses typed $metadata.httpStatusCode for status and reconstructs HTTP headers from typed output fields (ContentType, ContentLength, etc.). Zero any, zero biome-ignore, zero internal coupling — the SDK can refactor freely.
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:55:56.151648+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  category: risk
+  confidence: 0.95
+edges:
+  supported_by:
+  - target: SRC-AWS-SDK-MW
+    version: 1.0.0
+  - target: SRC-V4-PROMPT
+    version: 1.0.0

--- a/.lattice/theses/typed-errors.yaml
+++ b/.lattice/theses/typed-errors.yaml
@@ -1,0 +1,18 @@
+id: THX-TYPED-ERRORS
+type: thesis
+title: Silent error swallowing is a contract bug; consumers need typed errors
+body: 'v3 substituted an empty 200 stream for any non-fatal S3 error (NoSuchKey, NoSuchBucket, AccessDenied, InvalidRange). Consumers had no way to distinguish a zero-byte file from a swallowed 404. v4 throws typed S3ProxyError subclasses with the SDK error attached as cause, so frameworks render the right HTTP status. Confidence: high — the silent-200 path was actively misleading load balancers and CDN cache layers in real deployments.'
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:55:45.013848+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  category: technical
+  confidence: 0.95
+edges:
+  supported_by:
+  - target: SRC-V4-PROMPT
+    version: 1.0.0
+  - target: SRC-V4-MIGRATION
+    version: 1.0.0

--- a/.lattice/theses/web-standards.yaml
+++ b/.lattice/theses/web-standards.yaml
@@ -1,0 +1,16 @@
+id: THX-WEB-STANDARDS
+type: thesis
+title: Web Standards runtimes (Bun, Workers, Deno) need the same API as Node
+body: The library's reach extends beyond Node when proxy.fetch() returns a plain triple that fits cleanly in a Web Response. On Bun/Cloudflare Workers/Deno, Hono is the natural framework and the @hono/node-server conversion layer disappears entirely. Demonstrated by examples/hono-basic.ts; smoke gate confirms parity (mean=55-58ms across all three frameworks).
+status: active
+version: 1.0.0
+created_at: 2026-05-11T22:55:58.871075+00:00
+created_by: agent:claude
+requested_by: George Moon <george.moon@gmail.com>
+meta:
+  category: market
+  confidence: 0.85
+edges:
+  supported_by:
+  - target: SRC-HONO-PR
+    version: 1.0.0


### PR DESCRIPTION
Adopts [lattice](https://forkzero.ai/lattice) (v0.1.22 locally) for
queryable project knowledge — requirements, theses, sources, and
implementations as YAML nodes with explicit edges. Per #104's
follow-up theme of \"make the rationale findable, not just the diff.\"

## What you get

\`\`\`bash
$ lattice summary
  4 sources, 6 theses, 8 requirements, 8 implementations
  Requirements by resolution:
    0 unresolved, 8 verified, 0 blocked, 0 deferred, 0 wontfix
  Requirements by priority:
    3 P0, 3 P1, 2 P2
  Drift: none

$ lattice get THX-PURE-FETCH
  # → claim, supporting sources, derived requirements,
  #   satisfying implementations — one query, no grepping commits.
\`\`\`

## Backfilled state

| | count | examples |
|---|---|---|
| sources | 4 | v4-prompt, v4-migration, aws-sdk-mw, hono-pr |
| theses | 6 | typed-errors, decompose, pure-fetch, fail-fast-opt-out, sdk-public-api, web-standards |
| requirements | 8 | one per GH issue (#95-#101 + #104), all \`--derives-from\` the right thesis |
| implementations | 8 | each \`--satisfies\` its requirement, with files + test-command |

All 8 requirements resolved as \`verified\` (the v4 work is shipped).

## Why backfill instead of forward-only?

Picked option **2** from the earlier triage. The win isn't the audit
trail — that already lives in commit messages. The win is that
*future* work can call \`lattice plan REQ-NEW depends-on REQ-CORE-004\`
or \`lattice drift\` and find the existing structure already wired up.
A forward-only adoption would have left an empty graph and a stub.

## .gitignore subtlety

PR #105 gitignored \`.claude/\` as per-user tooling. \`lattice init --skill\`
generates \`SKILL.md\` and \`product-owner.md\` under \`.claude/\` —
those are project-scoped (they teach *any* agent how to work with
*this* lattice). So this PR carves an exception:

\`\`\`gitignore
.claude/*
!.claude/skills/
!.claude/agents/
\`\`\`

The per-user invariant is preserved (memory, prompts, projects/
remain ignored) but committed skills and agents flow.

## Test plan

- [x] \`lattice summary\` — 4/6/8/8, drift: none
- [x] \`lattice lint\` — No issues found
- [x] \`lattice drift\` — No drift detected
- [x] \`npm test\` — 49/49
- [x] \`npm run type-check\` — clean (both configs)
- [x] \`npx biome check\` — 0/0
- [x] \`npm run test:smoke\` — all 3 examples pass, latency baseline visible

## Not in this PR

- **Lattice in CI** (\`lattice drift\` as a gate). Worth doing once the
  team's actually using it for new work — premature now.
- **Lattice MCP server integration** (\`lattice mcp\`). The skill
  already lets me use the CLI; MCP is a follow-up if we want to
  remove the bash hop.
- **Re-modeling design decisions deeper than \"thesis\".** Some of the
  v4 calls (path-A vs path-B for Hono headers, verifyOnInit Option A
  from the design review) deserve their own thesis nodes if we expect
  them to be revisited. Left for the next time one of them comes up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)