### PR TITLE
chore(lattice): migrate to v0.2.0 schema

### DIFF
--- a/.lattice/config.yaml
+++ b/.lattice/config.yaml
@@ -2,3 +2,4 @@
 version: "1.0"
 project: "s3proxy"
 description: "Front AWS S3 with a web server that you control"
+schema_version: "0.2.0"


### PR DESCRIPTION
Trivial follow-up after lattice CLI bumped between sessions.

\`lattice migrate\` added \`schema_version: \"0.2.0\"\` to \`.lattice/config.yaml\`
and created an empty \`messages/\` node-type directory. No content changes.

Without this, every \`lattice\` invocation warns:
\`\`\`
Warning: This lattice uses schema unknown (current: 0.2.0).
Run 'lattice migrate' to update.
\`\`\`

After: \`lattice summary\` runs clean, \`lattice lint\` returns "No issues found".

## Test plan

- [x] \`lattice migrate\` ran clean (no content edits, 8 theses already in right shape)
- [x] \`lattice lint\` — No issues found
- [x] \`lattice summary\` — 7 / 8 / 12 / 8 / 0
- [x] \`npm test\` — 49/49
- [x] \`npx biome check\` — 0/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)